### PR TITLE
Use Gluon's built GraalVM

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,10 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup GraalVM environment
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: 21.0.0.java11
+      - name: Setup Gluon's GraalVM
+        uses: gluonhq/setup-graalvm@master
 
       - name: Install libraries
         run: sudo apt install libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libgl-dev libgtk-3-dev libpango1.0-dev libxtst-dev
@@ -33,7 +31,6 @@ jobs:
       - name: Gluon Build
         run: mvn -Pandroid client:build client:package
         env:
-          GRAALVM_HOME: ${{ env.JAVA_HOME }}
           GLUON_ANDROID_KEYSTOREPATH: ${{ steps.android_keystore_file.outputs.filePath }}
           GLUON_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.GLUON_ANDROID_KEYSTORE_PASSWORD }}
           GLUON_ANDROID_KEYALIAS: ${{ secrets.GLUON_ANDROID_KEYALIAS }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install libraries
         run: sudo apt install libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libgl-dev libgtk-3-dev libpango1.0-dev libxtst-dev

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: Apple-Actions/import-codesign-certs@v1
         with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,14 +6,12 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup GraalVM environment
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: 21.0.0.java11
+      - name: Setup Gluon's GraalVM
+        uses: gluonhq/setup-graalvm@master
 
       - uses: Apple-Actions/import-codesign-certs@v1
         with:
@@ -34,8 +32,6 @@ jobs:
 
       - name: Gluon Build
         run: mvn -Pios client:build client:package
-        env:
-          GRAALVM_HOME: ${{ env.JAVA_HOME }}
 
       - uses: Apple-Actions/upload-testflight-build@master
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,10 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup GraalVM environment
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: 21.0.0.java11
+      - name: Setup Gluon's GraalVM
+        uses: gluonhq/setup-graalvm@master
 
       - name: Install libraries
         run: sudo apt install libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libgl-dev libgtk-3-dev libpango1.0-dev libxtst-dev
@@ -28,8 +26,6 @@ jobs:
 
       - name: Gluon Build
         run: mvn -Pdesktop client:build client:package
-        env:
-          GRAALVM_HOME: ${{ env.JAVA_HOME }}
 
       - name: Copy native client to staging
         run: cp -r target/client/x86_64-linux/HelloGluon* staging

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install libraries
         run: sudo apt install libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libgl-dev libgtk-3-dev libpango1.0-dev libxtst-dev

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,13 +6,11 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup GraalVM environment
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: 21.0.0.java11
+      - name: Setup Gluon's GraalVM
+        uses: gluonhq/setup-graalvm@master
 
       - name: Make staging directory
         run: mkdir staging
@@ -24,8 +22,6 @@ jobs:
 
       - name: Gluon Build
         run: mvn -Pdesktop client:build client:package
-        env:
-          GRAALVM_HOME: ${{ env.JAVA_HOME }}
 
       - name: Copy native client to staging
         run: cp -r target/client/x86_64-darwin/HelloGluon* staging

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make staging directory
         run: mkdir staging

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make staging directory
         run: mkdir staging

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,10 +16,8 @@ jobs:
       - name: Visual Studio shell
         uses: egor-tensin/vs-shell@v1
 
-      - name: Setup GraalVM environment
-        uses: DeLaGuardo/setup-graalvm@master
-        with:
-          graalvm-version: 21.0.0.java11
+      - name: Setup Gluon's GraalVM
+        uses: gluonhq/setup-graalvm@master
 
       - name: Make staging directory
         run: mkdir staging
@@ -31,8 +29,6 @@ jobs:
 
       - name: Gluon Build
         run: mvn -Pdesktop client:build client:package
-        env:
-          GRAALVM_HOME: ${{ env.JAVA_HOME }}
 
       - name: Copy native client to staging
         run: cp -r target/client/x86_64-windows/HelloGluon.exe staging


### PR DESCRIPTION
Update the workflows to configure the environment with a version of GraalVM that is built by Gluon (See https://github.com/gluonhq/graal).

The sample workflows will use the latest release and they set the GITHUB_TOKEN secret to avoid reaching the GitHub API rate limit.