### PR TITLE
Add NSBluetoothAlwaysUsageDescription to avoid Apple’s warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <javafx.version>16</javafx.version>
         <charm.version>6.0.6</charm.version>
         <glisten.afterburner.version>2.0.5</glisten.afterburner.version>
-        <attach.version>4.0.11</attach.version>
+        <attach.version>4.0.12</attach.version>
         <connect.version>2.0.1</connect.version>
-        <javafx.maven.plugin.version>0.0.5</javafx.maven.plugin.version>
+        <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
         <gluonfx.maven.plugin.version>1.0.4</gluonfx.maven.plugin.version>
         <main.class>com.gluonhq.hello.HelloGluonApp</main.class>
     </properties>

--- a/src/main/resources/META-INF/substrate/ios/Partial-Info.plist
+++ b/src/main/resources/META-INF/substrate/ios/Partial-Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>The app might need access to Bluetooth</string>
+</dict>
+</plist>


### PR DESCRIPTION
Add a partial plist with the key and a short description. In theory this should avoid the usual warning from Apple.