### PR TITLE
Test preinstalled Android SDK and NDK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,21 +19,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libgl-dev libgtk-3-dev libpango1.0-dev libxtst-dev
-
-      - name: Setup Android Keystore
-        id: android_keystore_file
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'my.keystore'
-          encodedString: ${{ secrets.GLUON_ANDROID_KEYSTORE_BASE64 }}
-
+            
       - name: Gluon License
         uses: gluonhq/gluon-build-license@v1
         with:
           gluon-license: ${{ secrets.GLUON_LICENSE }}
 
       - name: Gluon Build
-        run: mvn -Pandroid gluonfx:build gluonfx:package
+        run: |
+          export ANDROID_SDK=$ANDROID_HOME
+          export ANDROID_NDK=$ANDROID_HOME/ndk/23.2.8568313
+          mvn -Pandroid gluonfx:build gluonfx:package
         env:
           GLUON_ANDROID_KEYSTOREPATH: ${{ steps.android_keystore_file.outputs.filePath }}
           GLUON_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.GLUON_ANDROID_KEYSTORE_PASSWORD }}


### PR DESCRIPTION
Since 1st August, NDK is set to 25, instead of 21, and that doesn't work.
This PR tries to uses NDK 23, the older version preinstalled with Ubuntu 20.04, and also prevents installing Android SDK.