### PR TITLE
Bump version of upload-artifact action

### DIFF
--- a/.github/workflows/aarch64-linux.yml
+++ b/.github/workflows/aarch64-linux.yml
@@ -36,7 +36,7 @@ jobs:
         run: cp -r target/gluonfx/aarch64-linux/HelloGluon* staging
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: staging

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -55,7 +55,7 @@ jobs:
         run: cp -r target/gluonfx/aarch64-android/gvm/HelloGluon.* staging
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: staging

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
         run: cp -r target/gluonfx/x86_64-linux/HelloGluon* staging
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: staging

--- a/.github/workflows/macos-aarch64.yml
+++ b/.github/workflows/macos-aarch64.yml
@@ -48,7 +48,7 @@ jobs:
           team-id: ${{ secrets.GLUON_MACSIGN_PREFIX }}
 
       - name: Upload (pkg)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: ${{ steps.outputfile.outputs.path }}

--- a/.github/workflows/macos-aarch64.yml
+++ b/.github/workflows/macos-aarch64.yml
@@ -83,7 +83,7 @@ jobs:
           echo ::set-output name=path::target/gluonfx/aarch64-darwin/HelloGluon-1.0.0.pkg
 
       - name: Upload (pkg store)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: PackageAppStore
           path: ${{ steps.outputfilestore.outputs.path }}

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -46,7 +46,7 @@ jobs:
           team-id: ${{ secrets.GLUON_MACSIGN_PREFIX }}
 
       - name: Upload (pkg)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: ${{ steps.outputfile.outputs.path }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload (pkg store)
         if: false # only upload aarch64 version
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: PackageAppStore
           path: ${{ steps.outputfilestore.outputs.path }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
           cp -r target/gluonfx/x86_64-windows/HelloGluon-1.0.msi staging
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: staging


### PR DESCRIPTION
as it `actions/upload-artifact: v2` was not only deprecated but also removed.